### PR TITLE
Initial Mac version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 # Shared object files
 *.so.*
+*.dylib
 # Generated header files
 redir.h
 unredir.h

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-CFLAGS = -fPIC -Wall -Wextra -O2 `sdl2-config --cflags` -g -m32
+DLLOADNAME ?= "libSDL2-2.0.so.0"
+CFLAGS = -fPIC -Wall -Wextra -O2 `sdl2-config --cflags` -g -m32 \
+-DDLLOADNAME=\"$(DLLOADNAME)\"
 LDFLAGS = -shared -ldl -m32
 TARGET = libSDL-1.2.so.0
 

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,44 @@
+DLLOADNAME ?= "libSDL2-2.0.0.dylib"
+CFLAGS += -fPIC -Wall -Wextra -O2 `sdl2-config --cflags` -g -DDLLOADNAME=\"$(DLLOADNAME)\"
+CFLAGS32 = $(CFLAGS) -arch i386
+CFLAGS64 = $(CFLAGS) -arch x86_64
+ALLARCHFLAGS = -arch i386 -arch x86_64 
+LIB_INSTALL_NAME ?= /opt/local/lib/libSDL-1.2.0.dylib
+LIB_COMPAT_VER ?= 12.0
+LIB_CURRENT_VER ?= 12.4
+
+
+LDFLAGS += -dynamiclib -compatibility_version $(LIB_COMPAT_VER) -current_version \
+$(LIB_CURRENT_VER) -install_name $(LIB_INSTALL_NAME) -ldl 
+TARGET = libSDL-1.2.0.dylib
+SRCS = main.c video.c audio.c audiocvt.c timer.c events.c joystick.c rwops.c
+OBJS = $(SRCS:.c=.o)
+HEADERS = redir.h unredir.h
+
+.PHONY: all
+all: $(TARGET)
+
+%.o: %.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS) $(ALLARCHFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(ALLARCHFLAGS)
+
+$(SRCS:.c=-32.d):%-32.d:%.c $(HEADERS)
+	$(CC) $(CFLAGS32) -MM $< >$@
+
+$(SRCS:.c=-64.d):%-64.d:%.c $(HEADERS)
+	$(CC) $(CFLAGS64) -MM $< >$@
+
+redir.h: symbols.x
+	sed 's/SDL2_SYMBOL(\([^,]*\),.*/#define \1 re\1/' $^ > $@
+
+unredir.h: symbols.x
+	sed 's/SDL2_SYMBOL(\([^,]*\),.*/#undef \1/' $^ > $@
+
+include $(SRCS:.c=-32.d)
+include $(SRCS:.c=-64.d)
+
+.PHONY: clean
+clean:
+	-$(RM) $(TARGET) $(OBJS) $(SRCS:.c=-32.d) $(SRCS:.c=-64.d) $(HEADERS)

--- a/main.c
+++ b/main.c
@@ -52,7 +52,7 @@ static Uint32 initflags1to2 (Uint32 flags) {
 
 static int initlib (void) {
 	if (!lib) {
-		lib = dlopen("libSDL2-2.0.so.0", RTLD_LAZY);
+		lib = dlopen(DLLOADNAME, RTLD_LAZY);
 		if (!lib) return -1;
 #define SDL2_SYMBOL(name, ret, param) \
 		r##name = dlsym(lib, #name); \


### PR DESCRIPTION
The library that can be opened can now be changed by passing DLLOADNAME to the make command.
The Mac makefile can also be passed LIB_COMPAT_VER, LIB_CURRENT_VER, and LIB_INSTALL_NAME to configure the created library.